### PR TITLE
Don't emit CFI for panic=abort

### DIFF
--- a/src/arm.rs
+++ b/src/arm.rs
@@ -2,7 +2,8 @@ use super::NonZero;
 
 macro_rules! set_jump_raw_impl {
     ($($tt:tt)*) => {
-        core::arch::asm!(
+        maybe_strip_cfi!(
+            (core::arch::asm!),
             $($tt)*
 
             // Callee saved registers.
@@ -29,11 +30,12 @@ macro_rules! set_jump_raw {
         set_jump_raw_impl!(
             "adr lr, {lander}",
             "push {{r6, r11, sp, lr}}",
-            ".cfi_adjust_cfa_offset 16",
+            [".cfi_adjust_cfa_offset 16"],
             "mov r1, sp",
             "bl {f}",
             "add sp, sp, 16",
-            ".cfi_adjust_cfa_offset -16",
+            [".cfi_adjust_cfa_offset -16"],
+            [],
 
             f = sym $f,
             inout("r0") $data => $val,
@@ -44,12 +46,13 @@ macro_rules! set_jump_raw {
         set_jump_raw_impl!(
             "adr lr, 2f",
             "push {{r6, r11, sp, lr}}",
-            ".cfi_adjust_cfa_offset 16",
+            [".cfi_adjust_cfa_offset 16"],
             "mov r1, sp",
             "bl {f}",
             "add sp, sp, 16",
-            ".cfi_adjust_cfa_offset -16",
+            [".cfi_adjust_cfa_offset -16"],
             "2:",
+            [],
 
             f = sym $f,
             inout("r0") $data => $val,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ macro_rules! maybe_strip_cfi {
 }
 
 // Windows do not use DWARF unwind info.
-#[cfg(windows)]
+#[cfg(any(windows, panic = "abort"))]
 macro_rules! maybe_strip_cfi {
     (($($head:tt)*), $($lit1:literal,)* $([$cfi:literal], $($lit2:literal,)*)* [], $($tail:tt)*) => {
         $($head)* (


### PR DESCRIPTION
Fix build error for panic=abort

```
error: this directive must appear between .cfi_startproc and .cfi_endproc directives
  --> /home/han/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sjlj2-0.3.0/src/./riscv64.rs:88:14
   |
88 |             ".cfi_remember_state",
   |              ^^^^^^^^^^^^^^^^^^^
   |
note: instantiated into assembly here
  --> <inline asm>:5:1
   |
5  | .cfi_remember_state
   | ^

error: this directive must appear between .cfi_startproc and .cfi_endproc directives
  --> /home/han/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sjlj2-0.3.0/src/./riscv64.rs:89:14
   |
89 |             ".cfi_undefined ra",
   |              ^^^^^^^^^^^^^^^^^
   |
note: instantiated into assembly here
  --> <inline asm>:6:1
   |
6  | .cfi_undefined ra
   | ^
```
