### PR TITLE
Rewrite to use asm_goto and avoid stack manipulation in ASM 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,10 +173,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Rust 1.79
+      - name: Install Rust 1.87
         run: |
           rustup update --no-self-update stable
-          rustup default 1.79
+          rustup default 1.87
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
         run: |
           for flags in {,--features=unwind}' '{,'--release -- --include-ignored'}; do
             echo RUN cargo test $flags
-            cargo test $flags
+            cargo test $flags -- --test-threads 1
           done
 
   test-exotic:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,14 +94,6 @@ jobs:
             cargo test $flags
           done
 
-      - name: Test asm-goto
-        if: matrix.rust == 'nightly'
-        run: |
-          for flags in '--features=unstable-asm-goto'{,',unwind'}' '{,'--release -- --include-ignored'}; do
-            echo RUN cargo test $flags
-            cargo test $flags
-          done
-
   test-exotic:
     needs: code-style
     timeout-minutes: 15
@@ -148,8 +140,6 @@ jobs:
         run: |
           nix develop --command cargo build $CARGO_ARGS
           nix develop --command cargo build $CARGO_ARGS --release
-          nix develop --command cargo build $CARGO_ARGS --features=unstable-asm-goto
-          nix develop --command cargo build $CARGO_ARGS --features=unstable-asm-goto --release
 
       - name: Test
         if: ${{ !matrix.nostd }}
@@ -157,12 +147,6 @@ jobs:
       - name: Test release
         if: ${{ !matrix.nostd }}
         run: nix develop --command cargo test --release
-      - name: Test asm-goto
-        if: ${{ !matrix.nostd }}
-        run: nix develop --command cargo test --features=unstable-asm-goto
-      - name: Test asm-goto release
-        if: ${{ !matrix.nostd }}
-        run: nix develop --command cargo test --features=unstable-asm-goto --release
 
   msrv:
     name: MSRV

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,6 @@ rust-version = "1.87" # asm_goto
 default = []
 unwind = []
 
-# Uses unstable rustc features.
-unstable-asm-goto = []
-
 [dependencies]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/oxalica/sjlj2"
 license = "MIT OR Apache-2.0"
 exclude = ["flake.nix", "flake.lock"]
 # NB. Sync with CI!
-rust-version = "1.79" # NonZero<T>, const blocks
+rust-version = "1.87" # asm_goto
 
 [features]
 default = []

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741513245,
-        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
+        "lastModified": 1753250450,
+        "narHash": "sha256-i+CQV2rPmP8wHxj0aq4siYyohHwVlsh40kV89f3nw1s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
+        "rev": "fc02ee70efb805d3b2865908a13ddd4474557ecf",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1736320768,
-        "narHash": "sha256-nIYdTAiKIGnFNugbomgBJR+Xv5F1ZQU+HfaBqJKroC0=",
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bc9c909d9ac828a039f288cf872d16d38185db8",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1741746673,
-        "narHash": "sha256-7L4J5F96ku6DBkbEwxNdPZF41bAEhMMoHUlZD/jGYq4=",
+        "lastModified": 1753411536,
+        "narHash": "sha256-lm88KTYlhsh5usJLGlWQbG4HWWr2FdO26TSssCw6Wdg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7af16cbd1464fddde8ad0c4ed7baaa2292445ba4",
+        "rev": "7ae12d14d6bb74acfadf31e17a204d928eaf77b8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     let
       inherit (nixpkgs) lib;
       eachSystem = lib.genAttrs lib.systems.flakeExposed;
-      date = "2025-03-01";
+      date = "2025-07-01";
     in
     {
       devShells = eachSystem (

--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -1,47 +1,44 @@
 use super::NonZero;
 
-#[cfg(not(target_os = "macos"))]
-macro_rules! set_jump_raw_impl {
-    ($($tt:tt)*) => {
-        maybe_strip_cfi!(
-            (core::arch::asm!),
-            $($tt)*
+// sp, x19, fp, lander
+#[repr(C, align(16))]
+pub(crate) struct Buf(pub [usize; 4]);
 
-            // Callee saved registers.
-            // lateout("sp") _, // sp
-            lateout("x16") _,
-            lateout("x17") _,
-            lateout("x18") _,
-            // lateout("x19") _, // LLVM reserved.
-            lateout("x20") _,
-            lateout("x21") _,
-            lateout("x22") _,
-            lateout("x23") _,
-            lateout("x24") _,
-            lateout("x25") _,
-            lateout("x26") _,
-            lateout("x27") _,
-            lateout("x28") _,
-            // lateout("x29") _, // LLVM reserved.
-            lateout("lr") _,
-            // Caller saved registers.
-            clobber_abi("C"),
-        )
-    }
-}
-
+// x18 is platform-reserved on darwin. Do not touch it at all.
+// See: <https://stackoverflow.com/questions/71152539/consequence-of-violating-macoss-arm64-calling-convention>
 #[cfg(target_os = "macos")]
 macro_rules! set_jump_raw_impl {
     ($($tt:tt)*) => {
-        maybe_strip_cfi!(
-            (core::arch::asm!),
-            $($tt)*
+        core::arch::asm!($($tt)*)
+    };
+}
+
+// On non-darwin platform, mark x18 clobbered.
+#[cfg(not(target_os = "macos"))]
+macro_rules! set_jump_raw_impl {
+    ($($tt:tt)*) => {
+        core::arch::asm!($($tt)* lateout("x18") _)
+    };
+}
+
+macro_rules! set_jump_raw {
+    ($buf_ptr:expr, $func:expr, $lander:block) => {
+        set_jump_raw_impl!(
+            "adr x1, {lander}",
+            "mov x2, sp",
+            "stp x2, x19, [x0]",
+            "stp fp, x1, [x0, #16]",
+            "bl {func}",
+
+            in("x0") $buf_ptr, // arg0
+            func = sym $func,
+            lander = label $lander,
 
             // Callee saved registers.
             // lateout("sp") _, // sp
             lateout("x16") _,
             lateout("x17") _,
-            // lateout("x18") _, // Macos reserved.
+            // lateout("x18") _, // See `set_jump_raw_impl`
             // lateout("x19") _, // LLVM reserved.
             lateout("x20") _,
             lateout("x21") _,
@@ -52,49 +49,10 @@ macro_rules! set_jump_raw_impl {
             lateout("x26") _,
             lateout("x27") _,
             lateout("x28") _,
-            // lateout("x29") _, // LLVM reserved.
+            // lateout("fp") _, // LLVM reserved.
             lateout("lr") _,
             // Caller saved registers.
             clobber_abi("C"),
-        )
-    }
-}
-
-macro_rules! set_jump_raw {
-    ($val:expr, $f:expr, $data:expr, $lander:block) => {
-        set_jump_raw_impl!(
-            "adr x2, {lander}",
-            "stp x2, x2, [sp, #-16]!",
-            [".cfi_adjust_cfa_offset 16"],
-            "stp x19, x29, [sp, #-16]!",
-            [".cfi_adjust_cfa_offset 16"],
-            "mov x1, sp",
-            "bl {f}",
-            "add sp, sp, 32",
-            [".cfi_adjust_cfa_offset -32"],
-            [],
-
-            f = sym $f,
-            lander = label $lander,
-            inout("x0") $data => $val,
-        )
-    };
-    ($val:expr, $f:expr, $data:expr) => {
-        set_jump_raw_impl!(
-            "adr x2, 2f",
-            "stp x2, x2, [sp, #-16]!",
-            [".cfi_adjust_cfa_offset 16"],
-            "stp x19, x29, [sp, #-16]!",
-            [".cfi_adjust_cfa_offset 16"],
-            "mov x1, sp",
-            "bl {f}",
-            "add sp, sp, 32",
-            [".cfi_adjust_cfa_offset -32"],
-            "2:",
-            [],
-
-            f = sym $f,
-            inout("x0") $data => $val,
         )
     };
 }
@@ -104,18 +62,19 @@ pub(crate) unsafe fn long_jump_raw(jp: *mut (), result: NonZero<usize>) -> ! {
     unsafe {
         maybe_strip_cfi!(
             (core::arch::asm!),
-            "ldp x19, x29, [x1]",
-            "ldr x2, [x1, #16]",
-            "add sp, x1, 32",
             [".cfi_remember_state"],
             [".cfi_undefined lr"],
-            "br x2",
+            "ldp x2, x19, [x1]",
+            "ldp fp, lr, [x1, #16]",
+            "mov sp, x2",
+            "str x0, [x1]",
+            "ret",
             [".cfi_restore_state"],
             [],
 
             in("x0") result.get(),
             in("x1") jp,
-            options(noreturn, nostack, readonly),
+            options(noreturn, nostack),
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,7 +376,7 @@ where
     };
 
     unsafe {
-        set_jump_raw!(&mut data, wrap::<T, F>, {
+        set_jump_raw!(&raw mut data, wrap::<T, F>, {
             unsafe {
                 let val = NonZero::new_unchecked(data.jmp_buf.assume_init().0[0]);
                 return lander(val);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,16 +66,6 @@
 //! - `unwind`: Enables unwinding across [`set_jump`] boundary from its `ordinary` closure, by
 //!   catching and resuming it. This feature requires `std`.
 //!
-//! - `unstable-asm-goto`: Enables uses of `asm_goto` and `asm_goto_with_outputs` unstable features.
-//!
-//!   This requires a nightly rustc, but produces more optimal code with one-less conditional jump.
-//!
-//!   ⚠️ Warning: `asm_goto_with_outputs` is [reported to be buggy][asm_goto_bug] in some cases. It
-//!   is unknown that if our code is affected. Do NOT enable this feature unless you accept the
-//!   risk.
-//!
-//! [asm_goto_bug]: https://github.com/llvm/llvm-project/issues/74483
-//!
 //! ## Supported architectures
 //!
 //! - x86 (i686)
@@ -102,8 +92,6 @@
 //!   - Slower `long_jump` because of more register restoring.
 //!
 //! [misopt]: https://github.com/rust-lang/rfcs/issues/2625
-#![cfg_attr(feature = "unstable-asm-goto", feature(asm_goto))]
-#![cfg_attr(feature = "unstable-asm-goto", feature(asm_goto_with_outputs))]
 #![cfg_attr(not(any(test, feature = "unwind")), no_std)]
 use core::marker::PhantomData;
 use core::mem::{ManuallyDrop, MaybeUninit};

--- a/src/riscv32.rs
+++ b/src/riscv32.rs
@@ -1,10 +1,13 @@
 use super::NonZero;
 
+// s0, s1, sp, lander
+#[repr(transparent)]
+pub(crate) struct Buf(pub [usize; 4]);
+
 #[cfg(target_feature = "e")]
 macro_rules! set_jump_raw_impl {
     ($($tt:tt)*) => {
-        maybe_strip_cfi!(
-            (core::arch::asm!),
+        core::arch::asm!(
             $($tt)*
 
             // Callee saved registers.
@@ -33,8 +36,7 @@ macro_rules! set_jump_raw_impl {
 #[cfg(not(target_feature = "e"))]
 macro_rules! set_jump_raw_impl {
     ($($tt:tt)*) => {
-        maybe_strip_cfi!(
-            (core::arch::asm!),
+        core::arch::asm!(
             $($tt)*
 
             // Callee saved registers.
@@ -72,42 +74,18 @@ macro_rules! set_jump_raw_impl {
 }
 
 macro_rules! set_jump_raw {
-    ($val:expr, $f:expr, $data:expr, $lander:block) => {
+    ($buf_ptr:expr, $func:expr, $lander:block) => {
         set_jump_raw_impl!(
             "la a1, {lander}",
-            "addi sp, sp, -16",
-            [".cfi_adjust_cfa_offset 16"],
-            "sw a1, (sp)",
-            "sw s0, 4(sp)",
-            "sw s1, 8(sp)",
-            "mv a1, sp",
-            "call {f}",
-            "addi sp, sp, 16",
-            [".cfi_adjust_cfa_offset -16"],
-            [],
+            "sw s0,   (a0)",
+            "sw s1,  4(a0)",
+            "sw sp,  8(a0)",
+            "sw a1, 12(a0)",
+            "call {func}",
 
-            f = sym $f,
-            inout("a0") $data => $val,
+            in("a0") $buf_ptr, // arg0
+            func = sym $func,
             lander = label $lander,
-        )
-    };
-    ($val:expr, $f:expr, $data:expr) => {
-        set_jump_raw_impl!(
-            "la a1, 2f",
-            "addi sp, sp, -16",
-            [".cfi_adjust_cfa_offset 16"],
-            "sw a1, (sp)",
-            "sw s0, 4(sp)",
-            "sw s1, 8(sp)",
-            "mv a1, sp",
-            "call {f}",
-            "addi sp, sp, 16",
-            [".cfi_adjust_cfa_offset -16"],
-            "2:",
-            [],
-
-            f = sym $f,
-            inout("a0") $data => $val,
         )
     };
 }
@@ -117,18 +95,21 @@ pub(crate) unsafe fn long_jump_raw(jp: *mut (), result: NonZero<usize>) -> ! {
     unsafe {
         maybe_strip_cfi!(
             (core::arch::asm!),
-            "lw a2, 0(a1)",
-            "lw s0, 4(a1)",
-            "lw s1, 8(a1)",
-            "addi sp, a1, 16",
+
             [".cfi_remember_state"],
             [".cfi_undefined ra"],
+            "lw s0,   (a0)",
+            "sw a1,   (a0)",
+            "lw s1,  4(a0)",
+            "lw sp,  8(a0)",
+            "lw a2, 12(a0)",
             "jalr x0, a2",
             [".cfi_restore_state"],
             [],
-            in("a0") result.get(),
-            in("a1") jp,
-            options(noreturn, nostack, readonly),
+
+            in("a0") jp,
+            in("a1") result.get(),
+            options(noreturn, nostack),
         )
     }
 }

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -1,10 +1,27 @@
 use super::NonZero;
 
-macro_rules! set_jump_raw_impl {
-    ($($tt:tt)*) => {
-        maybe_strip_cfi!(
-            (core::arch::asm!),
-            $($tt)*
+// si, sp, bp, lander
+#[repr(transparent)]
+pub(crate) struct Buf(pub [usize; 4]);
+
+macro_rules! set_jump_raw {
+    ($buf_ptr:expr, $func:expr, $lander:block) => {
+        core::arch::asm!(
+            "call 2f",
+            "2:",
+            "popl %eax",
+            "addl $({lander} - 2b), %eax",
+            "movl %esi,   (%ecx)",
+            "movl %esp,  4(%ecx)",
+            "movl %ebp,  8(%ecx)",
+            "movl %eax, 12(%ecx)",
+            "call {func}",
+
+            in("cx") $buf_ptr, // arg0 for fastcall
+            func = sym $func,
+            lander = label $lander,
+            // Workaround: <https://github.com/rust-lang/rust/issues/74558>
+            options(att_syntax),
 
             // Callee saved registers.
             // lateout("si") _, // LLVM reserved.
@@ -13,64 +30,7 @@ macro_rules! set_jump_raw_impl {
             lateout("bx") _,
             lateout("di") _,
             // Caller saved registers.
-            clobber_abi("C"),
-        )
-    };
-}
-
-macro_rules! set_jump_raw {
-    ($val:expr, $f:expr, $data:expr, $lander:block) => {
-        set_jump_raw_impl!(
-            "call 2f",
-            "2:",
-            [".cfi_adjust_cfa_offset 4"],
-            "addl $({lander} - 2b), (%esp)",
-            "pushl %esi",
-            [".cfi_adjust_cfa_offset 4"],
-            "pushl %ebp",
-            [".cfi_adjust_cfa_offset 4"],
-            "pushl %esp",
-            [".cfi_adjust_cfa_offset 4"],
-            "pushl {data}",
-            [".cfi_adjust_cfa_offset 4"],
-            "call {f}",
-            "addl $20, %esp",
-            [".cfi_adjust_cfa_offset -20"],
-            [],
-
-            f = sym $f,
-            data = in(reg) $data,
-            out("ax") $val,
-            lander = label $lander,
-            // Workaround: <https://github.com/rust-lang/rust/issues/74558>
-            options(att_syntax),
-        )
-    };
-    ($val:expr, $f:expr, $data:expr) => {
-        set_jump_raw_impl!(
-            "call 2f",
-            "2:",
-            [".cfi_adjust_cfa_offset 4"],
-            "addl $(3f - 2b), (%esp)",
-            "pushl %esi",
-            [".cfi_adjust_cfa_offset 4"],
-            "pushl %ebp",
-            [".cfi_adjust_cfa_offset 4"],
-            "pushl %esp",
-            [".cfi_adjust_cfa_offset 4"],
-            "pushl {data}",
-            [".cfi_adjust_cfa_offset 4"],
-            "call {f}",
-            "addl $20, %esp",
-            [".cfi_adjust_cfa_offset -20"],
-            "3:",
-            [],
-
-            f = sym $f,
-            data = in(reg) $data,
-            out("ax") $val,
-            // Workaround: <https://github.com/rust-lang/rust/issues/74558>
-            options(att_syntax),
+            clobber_abi("fastcall"),
         )
     };
 }
@@ -81,19 +41,19 @@ pub(crate) unsafe fn long_jump_raw(buf: *mut (), result: NonZero<usize>) -> ! {
         maybe_strip_cfi!(
             (core::arch::asm!),
 
-            "mov edx, dword ptr [ecx - 4]",
-            "mov esi, dword ptr [ecx - 8]",
-            "mov ebp, dword ptr [ecx - 12]",
-            "mov esp, ecx",
             [".cfi_remember_state"],
             [".cfi_undefined eip"],
-            "jmp edx",
+            "mov esi, [ecx]",
+            "mov [ecx], eax",
+            "mov esp, [ecx + 4]",
+            "mov ebp, [ecx + 8]",
+            "jmp dword ptr [ecx + 12]",
             [".cfi_restore_state"],
             [],
 
-            in("cx") buf as usize + 12,
+            in("cx") buf,
             in("ax") result.get(),
-            options(noreturn, nostack, readonly),
+            options(noreturn, nostack),
         )
     }
 }

--- a/src/x86_64.rs
+++ b/src/x86_64.rs
@@ -1,31 +1,24 @@
 use super::NonZero;
 
+// rbx, rsp, rbp, lander
+#[repr(transparent)]
+pub(crate) struct Buf(pub [usize; 4]);
+
 macro_rules! set_jump_raw {
-    ($val:expr, $f:expr, $data:expr, $lander:block) => {
-        maybe_strip_cfi!(
-            (core::arch::asm!),
-
+    ($buf_ptr:expr, $func:expr, $lander:block) => {
+        core::arch::asm!(
             "lea rax, [rip + {lander}]",
-            "mov rsi, rsp",
-            "push rax",
-            [".cfi_adjust_cfa_offset 8"],
-            "push rax", // Align the stack.
-            [".cfi_adjust_cfa_offset 8"],
-            "push rbx",
-            [".cfi_adjust_cfa_offset 8"],
-            "push rbp",
-            [".cfi_adjust_cfa_offset 8"],
-            "call {f}",
-            "add rsp, 32",
-            [".cfi_adjust_cfa_offset -32"],
-            [],
+            "mov [rdi     ], rbx",
+            "mov [rdi +  8], rsp",
+            "mov [rdi + 16], rbp",
+            "mov [rdi + 24], rax",
+            "call {func}",
 
-            f = sym $f,
-            in("rdi") $data,
-            out("rax") $val,
+            in("rdi") $buf_ptr, // arg0
+            func = sym $func,
             lander = label $lander,
 
-            // Callee saved registers.
+            // Clobber more default callee saved registers.
             // lateout("bx") _, // LLVM reserved.
             // lateout("sp") _, // sp
             // lateout("bp") _, // LLVM reserved.
@@ -33,37 +26,8 @@ macro_rules! set_jump_raw {
             lateout("r13") _,
             lateout("r14") _,
             lateout("r15") _,
-            // Caller saved registers.
-            clobber_abi("sysv64"),
-        )
-    };
-    ($val:expr, $f:expr, $data:expr) => {
-        maybe_strip_cfi!(
-            (core::arch::asm!),
 
-            "push rbx",
-            [".cfi_adjust_cfa_offset 8"],
-            "push rbp",
-            [".cfi_adjust_cfa_offset 8"],
-            "mov rsi, rsp",
-            "call {f}",
-            "add rsp, 16",
-            [".cfi_adjust_cfa_offset -16"],
-            [],
-
-            f = sym $f,
-            in("rdi") $data,
-            out("rax") $val,
-
-            // Callee saved registers.
-            // lateout("bx") _, // LLVM reserved.
-            // lateout("sp") _, // sp
-            // lateout("bp") _, // LLVM reserved.
-            lateout("r12") _,
-            lateout("r13") _,
-            lateout("r14") _,
-            lateout("r15") _,
-            // Caller saved registers.
+            // Default caller saved registers.
             clobber_abi("sysv64"),
         )
     };
@@ -71,45 +35,23 @@ macro_rules! set_jump_raw {
 
 #[inline]
 pub(crate) unsafe fn long_jump_raw(jp: *mut (), result: NonZero<usize>) -> ! {
-    #[cfg(feature = "unstable-asm-goto")]
     unsafe {
         maybe_strip_cfi!(
             (core::arch::asm!),
 
-            "mov rdx, qword ptr [rcx - 16]",
-            "mov rbx, qword ptr [rcx - 24]",
-            "mov rbp, qword ptr [rcx - 32]",
-            "mov rsp, rcx",
             [".cfi_remember_state"],
             [".cfi_undefined rip"],
-            "jmp rdx",
+            "mov rbx, [rcx     ]",
+            "mov rsp, [rcx +  8]",
+            "mov rbp, [rcx + 16]",
+            "mov [rcx], rax",
+            "jmp qword ptr [rcx + 24]",
             [".cfi_restore_state"],
             [],
 
             in("cx") jp,
             in("ax") result.get(),
-            options(noreturn, nostack, readonly),
-        )
-    }
-
-    #[cfg(not(feature = "unstable-asm-goto"))]
-    unsafe {
-        maybe_strip_cfi!(
-            (core::arch::asm!),
-
-            "mov rdx, qword ptr [rcx - 8]",
-            "mov rbp, qword ptr [rcx]",
-            "mov rbx, qword ptr [rcx + 8]",
-            "mov rsp, rcx",
-            [".cfi_remember_state"],
-            [".cfi_undefined rip"],
-            "jmp rdx",
-            [".cfi_restore_state"],
-            [],
-
-            in("cx") jp,
-            in("ax") result.get(),
-            options(noreturn, nostack, readonly),
+            options(noreturn, nostack),
         )
     }
 }


### PR DESCRIPTION
- Simplifies setup code and no CFI directive is needed for SP changes.
- Hopefully fix frame pointer corruption issue on aarch64-darwin (~~and i686-windows?~~ No it doesn't).
- Always use asm_goto. It would be possible to switch to `usize` payload. `NonZero` is unnecessary with asm_goto.